### PR TITLE
Default setting condition when environment keys are not yet set like …

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -24,12 +24,18 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('SECRET_KEY')
+if 'SECRET_KEY' in os.environ:
+  SECRET_KEY = os.getenv('SECRET_KEY')
+else:  
+  SECRET_KEY = 'foofigher'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS")
+if 'ALLOWED_HOSTS' in os.environ:
+  ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS")
+else:   
+  ALLOWED_HOSTS = ['*']
 
 
 # Application definition
@@ -129,8 +135,9 @@ DATABASES = {
     }
 }
 
-database_url = os.getenv("DATABASE_URL")
-DATABASES['default'] = dj_database_url.parse(database_url) 
+
+#database_url = os.getenv("DATABASE_URL")
+#DATABASES['default'] = dj_database_url.parse(database_url) 
 # DATABASES = {
 #     'default': {
 #         'ENGINE': 'django.db.backends.postgresql',
@@ -255,8 +262,12 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # EMAIL_USE_TLS = True
 # EMAIL_PORT = '587'
 
-STRIPE_API_PUBLISHABLE_KEY = os.getenv('STRIPE_API_PUBLISHABLE_KEY')
-STRIPE_API_SECRET_KEY = os.getenv('STRIPE_API_SECRET_KEY')
+if 'STRIPE_API_PUBLISHABLE_KEY' in os.environ and 'STRIPE_API_SECRET_KEY' in os.environ:
+  STRIPE_API_PUBLISHABLE_KEY = os.getenv('STRIPE_API_PUBLISHABLE_KEY')
+  STRIPE_API_SECRET_KEY = os.getenv('STRIPE_API_SECRET_KEY')
+else:  
+  STRIPE_API_PUBLISHABLE_KEY = 'foofighter'
+  STRIPE_API_SECRET_KEY = 'foofighter'
 
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 django_heroku.settings(locals())


### PR DESCRIPTION
…in the .env file
I could not run the project from my Debian and macOS. I guess your IDE creates an .env file with key/value what Django pics up when you run `python manager.py`.
So I add some if conditions to the setting file.

I like your idea of cloning Amazon, and would like to work with in this.

